### PR TITLE
update the status port on stop and exception

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -161,8 +161,15 @@ void Task::pushAllData()
 //     TaskBase::errorHook();
 // }
 
+void Task::exceptionHook()
+{
+    updateIOStatus();
+    return TaskBase::exceptionHook();
+}
+
 void Task::stopHook()
 {
+    updateIOStatus();
     RTT::extras::FileDescriptorActivity* fd_activity =
         getActivity<RTT::extras::FileDescriptorActivity>();
     if (fd_activity)

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -92,13 +92,7 @@ namespace iodrivers_base {
          */
         void updateHook();
 
-        /** This hook is called by Orocos when the component is in the
-         * RunTimeError state, at each activity step. See the discussion in
-         * updateHook() about triggering options.
-         *
-         * Call recover() to go back in the Runtime state.
-         */
-        // void errorHook();
+        void exceptionHook();
 
         /** This hook is called by Orocos when the state machine transitions
          * from Running to Stopped after stop() has been called.


### PR DESCRIPTION
It makes sure that we have the latest information on hand if an
error occurs. Currently, having a timeout in configure() would lead
to NOT having the status information.
