### PR TITLE
Moved initialization code into configure hook

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -59,6 +59,9 @@ bool Task::configureHook()
 
     if (mDriver->getFileDescriptor() != Driver::INVALID_FD)
     {
+        if (_io_raw_in.connected())
+            throw std::runtime_error("cannot use the io_raw_in port and a normal I/O mechanism at the same time");
+
         RTT::extras::FileDescriptorActivity* fd_activity =
             getActivity<RTT::extras::FileDescriptorActivity>();
         if (fd_activity)


### PR DESCRIPTION
This is to allow the drivers to already communicate with the device
in the configure hook.

Cleaned-up doubled error checks in the process.
