### PR TITLE
never wait more than 10ms between two reads in the port-based com method

### DIFF
--- a/tasks/PortStream.cpp
+++ b/tasks/PortStream.cpp
@@ -23,8 +23,8 @@ void PortStream::waitRead(base::Time const& timeout)
     uint64_t full_timeout = timeout.toMicroseconds();
     if (full_timeout > 10000)
     {
-        count = 10;
-        sleep_time = full_timeout / 10;
+        sleep_time = 10000;
+        count = (full_timeout + sleep_time - 1) / sleep_time;
     }
     else
     {


### PR DESCRIPTION
We're still using a busy-wait read loop when communicating through
ports. The current method to determine the wait time was to use
1/10th of the total timeout when the timeout is greater than 10ms,
and simply use the total timeout if lower than 10ms.

However, this leads to really big sleep times if the requested timeout
is high (e.g. 1s for 10s timeout), which causes the system to drop
data unless the input buffer sizes are insanely huge.

Use 10ms as a "middle-ground" between CPU load (while busy-waiting) and
reading the input port "often enough". This is truly a workaround, the
proper fix would be to (finally !) be port-triggered.
