### PR TITLE
properly handle RawPacket samples that are bigger than the driver's internal buffer

### DIFF
--- a/tasks/PortStream.hpp
+++ b/tasks/PortStream.hpp
@@ -14,7 +14,6 @@ class PortStream : public IOStream
     RTT::InputPort<RawPacket>& mIn;
     RTT::OutputPort<RawPacket>& mOut;
 
-    bool mHasRead;
     RawPacket mPacketRead;
     RawPacket mPacketWrite;
 


### PR DESCRIPTION
There is really no reason to reject those. The device might send
multiple packets at once, and the driver internal buffer is only
required to be as big as the biggest packet (even though
performance would be better if it is a few times as large)

This removes the need for the mHasPacket flag as well.
