### PR TITLE
fix ownership of the listener

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -180,6 +180,7 @@ void Task::cleanupHook()
     {
         mDriver->removeListener(mListener);
         mDriver->close();
+        mDriver = 0;
     }
 
     TaskBase::cleanupHook();

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -28,7 +28,11 @@ Task::Task(std::string const& name, RTT::ExecutionEngine* engine)
 
 Task::~Task()
 {
-    delete mListener;
+    // if mDriver is not NULL, we assume that for whatever reason, cleanupHook
+    // hasn't been called. We can't delete mListener then because it might have
+    // been deleted when the subclass deleted the driver object.
+    if (!mDriver)
+        delete mListener;
 }
 
 void Task::setDriver(Driver* driver)


### PR DESCRIPTION
Listeners are owned by the driver. Under the current scheme, the task
was trying to reuse the same listener object across drivers which was
leading to a weird and error-prone gymnastic, where we had to remove
the listener before the subclass(es) delete their drivers.

This changes the scheme so that a new listener is allocated for each
new driver in setDriver.

The only downside of doing so is that the "old" driver keeps its listener
attached. Commonly, a new driver gets allocated in configureHook,
which will work as-is under the new scheme. Reusing the same
driver will also work. The only scheme that will change is if
one sets a new driver, but keeps on using the old driver.
Either "on the side", or by calling setDriver again. Under this usage,
that I've never seen in the wild, the old driver will still be tied
to the I/O monitoring ports. If such usage do exist, tasks that
do so will now need to call detachDriver() explicitly.