### PR TITLE
Implement configure guard

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 include(iodrivers_baseTaskLib)
 ADD_LIBRARY(${IODRIVERS_BASE_TASKLIB_NAME} SHARED 
-    PortStream.cpp ${IODRIVERS_BASE_TASKLIB_SOURCES})
+    PortStream.cpp ConfigureGuard.cpp ${IODRIVERS_BASE_TASKLIB_SOURCES})
 
 add_dependencies(${IODRIVERS_BASE_TASKLIB_NAME}
     regen-typekit)
@@ -18,6 +18,6 @@ INSTALL(TARGETS ${IODRIVERS_BASE_TASKLIB_NAME}
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib/orocos)
 
-INSTALL(FILES ${IODRIVERS_BASE_TASKLIB_HEADERS}
+INSTALL(FILES ${IODRIVERS_BASE_TASKLIB_HEADERS} ConfigureGuard.hpp
     DESTINATION include/orocos/iodrivers_base)
 

--- a/tasks/ConfigureGuard.cpp
+++ b/tasks/ConfigureGuard.cpp
@@ -1,0 +1,38 @@
+#include "ConfigureGuard.hpp"
+#include <rtt/extras/FileDescriptorActivity.hpp>
+
+using namespace iodrivers_base;
+
+ConfigureGuard::ConfigureGuard(iodrivers_base::Task *task)
+    : m_task(task)
+    , m_committed(false)
+{
+}
+
+ConfigureGuard::~ConfigureGuard()
+{
+    if (!m_committed)
+    {
+        RTT::extras::FileDescriptorActivity* fd_activity =
+            m_task->getActivity<RTT::extras::FileDescriptorActivity>();
+        if (fd_activity)
+        {
+            fd_activity->clearAllWatches();
+            fd_activity->setTimeout(0);
+        }
+
+        if (m_task->getDriver())
+        {
+            iodrivers_base::Driver *driver = m_task->getDriver();
+
+            m_task->detachDriver();
+            driver->close();
+        }
+    }
+}
+
+void ConfigureGuard::commit()
+{
+    m_committed = true;
+}
+

--- a/tasks/ConfigureGuard.hpp
+++ b/tasks/ConfigureGuard.hpp
@@ -1,0 +1,23 @@
+#ifndef IODRIVERS_BASE_OROGEN_CONFIGUREGUARD_HPP
+#define IODRIVERS_BASE_OROGEN_CONFIGUREGUARD_HPP
+
+#include <iodrivers_base/Task.hpp>
+#include <iodrivers_base/Driver.hpp>
+
+namespace iodrivers_base {
+
+class ConfigureGuard
+{
+private:
+    iodrivers_base::Task *m_task;
+    bool m_committed;
+
+public:
+    explicit ConfigureGuard(iodrivers_base::Task *task);
+    ~ConfigureGuard();
+    void commit();
+};
+
+}
+
+#endif

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -9,6 +9,7 @@ namespace iodrivers_base {
     class Driver;
     class PortListener;
     class PortStream;
+    class ConfigureGuard;
 
     /** Generic integration of an iodrivers_base::Driver in oroGen
      *
@@ -58,7 +59,7 @@ namespace iodrivers_base {
     class Task : public TaskBase
     {
 	friend class TaskBase;
-
+    friend class ConfigureGuard;
     protected:
         Driver* mDriver;
 


### PR DESCRIPTION
This should be used by iodrivers_base::Task subclasses in order to guarantee an acceptable level of exception-safety in configureHook(). Follow-up from the discussion that took place in Brazilian-Institute-of-Robotics/drivers-orogen-usbl_evologics#28.

Example usage:

```cpp
#include <iodrivers_base/ConfigureGuard.hpp>
using iodrivers_base::ConfigureGuard;

bool Task::configureHook()
{
    ConfigureGuard guard(this);
    ...
    guard.commit();
    return true;
}
```

The behavior may be tested using [this dummy component](https://github.com/g-arjones/drivers-orogen-dummy_component).