### PR TITLE
Fix leaking mListener

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -51,6 +51,8 @@ void Task::detachDriver()
     {
         mDriver->removeListener(mListener);
         mDriver = 0;
+        delete mListener;
+        mListener = 0;
     }
 }
 


### PR DESCRIPTION
As soon as the listener is removed, the driver no longer owns it and the task should delete it otherwise it is most likely going to be leaked when a new driver instance is set.