### PR TITLE
Small fix in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ void Task::cleanupHook()
     TaskBase::cleanupHook();
     // Not strictly necessary, the driver will be deleted on the next
     // successful configureHook anyways. YMMV.
-    m_driver.release();
+    m_driver.reset();
 }
 ~~~
 


### PR DESCRIPTION
Release returns a pointer to the object and releases the ownership from the smart pointer.
If the object isn't deleted somewhere else this would be a memory leak.