### PR TITLE
fix handling of processIO on non-FileDescriptorActivity deployments

### DIFF
--- a/iodrivers_base.orogen
+++ b/iodrivers_base.orogen
@@ -62,6 +62,17 @@ task_context "Proxy", subclasses: "Task" do
     fd_driven
 end
 
+# Test task used to verify the behavior of iodrivers_base::Task in a FDA
+# setting
+#
+# It will fail during execution if iodrivers_base::Task's implementation does
+# call processIO without any data on input
+task_context "test::FDTask", subclasses: "Task" do
+    output_port "rx", "/iodrivers_base/RawPacket"
+
+    fd_driven
+end
+
 # Test task used to verify the behavior of iodrivers_base::Task in a periodic
 # setting
 #

--- a/tasks/Proxy.cpp
+++ b/tasks/Proxy.cpp
@@ -111,4 +111,3 @@ void Proxy::cleanupHook()
     delete mDriver;
     mDriver = 0;
 }
-

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -54,7 +54,7 @@ namespace iodrivers_base {
      * The device object is owned by the subclass, which is responsible for its
      * destruction. setDriver may be called more than once with the same device
      * (so, it's OK to allocate the device as an attribute instead of allocating
-     * on the heap). 
+     * on the heap).
      *
      * Calling setDriver adds connections between the driver and task ports. If
      * this connection must be removed (to get a "detached" device), one must
@@ -98,8 +98,12 @@ namespace iodrivers_base {
         void pushAllData();
 
         /** Returns true if there is some I/O available to read on the driver
+         *
+         * @param first_time whether this is the first time hasIO was called within
+         *    updateHook, or a subsequent one. This adds a small optimization in the
+         *    comm FileDescriptorActivity case
          */
-        bool hasIO();
+        bool hasIO(bool first_time = true);
 
         /** Called back by the updateHook. It must be reimplemented to process
          * all packets that are currently queued in the driver
@@ -142,7 +146,7 @@ namespace iodrivers_base {
          *
          * The error(), exception() and fatal() calls, when called in this hook,
          * allow to get into the associated RunTimeError, Exception and
-         * FatalError states. 
+         * FatalError states.
          *
          * In the first case, updateHook() is still called, and recover() allows
          * you to go back into the Running state.  In the second case, the

--- a/tasks/test/FDTask.cpp
+++ b/tasks/test/FDTask.cpp
@@ -1,6 +1,6 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
-#include "PeriodicTask.hpp"
+#include "FDTask.hpp"
 #include "../ConfigureGuard.hpp"
 
 using namespace iodrivers_base;
@@ -26,16 +26,16 @@ namespace
     };
 }
 
-PeriodicTask::PeriodicTask(std::string const& name)
-    : PeriodicTaskBase(name)
+FDTask::FDTask(std::string const& name)
+    : FDTaskBase(name)
 {
 }
 
-PeriodicTask::~PeriodicTask()
+FDTask::~FDTask()
 {
 }
 
-bool PeriodicTask::configureHook()
+bool FDTask::configureHook()
 {
     unique_ptr<Driver> driver(new DummyDriver());
     // Un-configure the device driver if the configure fails.
@@ -48,7 +48,7 @@ bool PeriodicTask::configureHook()
 
     // This is MANDATORY and MUST be called after the setDriver but before you do
     // anything with the driver
-    if (!PeriodicTaskBase::configureHook())
+    if (!FDTaskBase::configureHook())
         return false;
 
     // If some device configuration was needed, it must be done after the
@@ -59,17 +59,17 @@ bool PeriodicTask::configureHook()
     return true;
 
 }
-bool PeriodicTask::startHook()
+bool FDTask::startHook()
 {
-    if (! PeriodicTaskBase::startHook())
+    if (! FDTaskBase::startHook())
         return false;
     return true;
 }
-void PeriodicTask::updateHook()
+void FDTask::updateHook()
 {
-    PeriodicTaskBase::updateHook();
+    FDTaskBase::updateHook();
 }
-void PeriodicTask::processIO()
+void FDTask::processIO()
 {
     uint8_t buffer[DUMMY_BUFFER_SIZE];
     int packet_size = mDriver->readPacket(buffer, DUMMY_BUFFER_SIZE);
@@ -79,15 +79,15 @@ void PeriodicTask::processIO()
     packet.data = std::vector<uint8_t>(buffer, buffer + packet_size);
     _rx.write(packet);
 }
-void PeriodicTask::errorHook()
+void FDTask::errorHook()
 {
-    PeriodicTaskBase::errorHook();
+    FDTaskBase::errorHook();
 }
-void PeriodicTask::stopHook()
+void FDTask::stopHook()
 {
-    PeriodicTaskBase::stopHook();
+    FDTaskBase::stopHook();
 }
-void PeriodicTask::cleanupHook()
+void FDTask::cleanupHook()
 {
-    PeriodicTaskBase::cleanupHook();
+    FDTaskBase::cleanupHook();
 }

--- a/tasks/test/FDTask.hpp
+++ b/tasks/test/FDTask.hpp
@@ -1,0 +1,94 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef IODRIVERS_BASE__TEST_FDTASK_TASK_HPP
+#define IODRIVERS_BASE__TEST_FDTASK_TASK_HPP
+
+#include "iodrivers_base/test/FDTaskBase.hpp"
+
+namespace iodrivers_base{
+namespace test{
+    /** Test task for deployed iodrivers_base tasks that run on non-FD activities
+     */
+    class FDTask : public FDTaskBase
+    {
+        friend class FDTaskBase;
+
+    protected:
+        std::unique_ptr<Driver> mDriver;
+
+        void processIO();
+
+    public:
+        /** TaskContext constructor for FDTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        FDTask(std::string const& name = "iodrivers_base::test::FDTask");
+
+        /** Default deconstructor of FDTask
+         */
+        ~FDTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+}
+
+#endif
+


### PR DESCRIPTION
With FileDescriptorActivity, there is essentially a loop that goes
through the activity itself until there is no data on the file
descriptor. The activity calls select() which triggers if there
is data, and calls updateHook and then processIO.

This does not work for the two other deployment modes (ports and
other types of activites). The base implementation of updateHook
only calls hasIO once, and loops for packets that are buffered. That's
fine if the driver's internal buffer is much bigger than the data
that may be queued on the I/O, but otherwise we end up with a queue that
never empties.

This commit changes the behavior from an if() to a while()